### PR TITLE
Special delete for Cities Quotes States tables

### DIFF
--- a/database/table_creation/table_cities.sql
+++ b/database/table_creation/table_cities.sql
@@ -1,43 +1,44 @@
--- CITIES TABLE
+PRAGMA foreign_keys = ON;
+
 CREATE TABLE IF NOT EXISTS cities (
-    city_id INTEGER PRIMARY KEY,
-    name VARCHAR,
-    abbreviation VARCHAR,
+    city_id INTEGER PRIMARY KEY AUTOINCREMENT ,
+    name VARCHAR NOT NULL,
+    abbreviation VARCHAR NOT NULL,
     state_id INTEGER,
     coordinate_x DOUBLE PRECISION(10, 4),
     coordinate_y DOUBLE PRECISION(10, 4),
 
     FOREIGN KEY (state_id) REFERENCES states(state_id)
+        ON DELETE CASCADE
 );
 
-INSERT INTO cities (city_id, name, abbreviation, state_id, coordinate_x, coordinate_y) VALUES
-(1, 'Atlanta', 'ATL', 1, 33.7490, -84.3880),               -- Georgia
-(2, 'Boston', 'BOS', 2, 42.3601, -71.0589),                -- Massachusetts
-(3, 'Cleveland', 'CLE', 3, 41.4995, -81.6954),             -- Ohio
-(4, 'New Orleans', 'NO', 4, 29.9511, -90.0715),            -- Louisiana
-(5, 'Chicago', 'CHI', 5, 41.8781, -87.6298),               -- Illinois
-(6, 'Dallas', 'DAL', 6, 32.7767, -96.7970),                -- Texas
-(7, 'Denver', 'DEN', 7, 39.7392, -104.9903),               -- Colorado
-(8, 'Golden State', 'GSW', 8, 37.7749, -122.4194),         -- California
-(9, 'Houston', 'HOU', 6, 29.7604, -95.3698),               -- Texas
-(10, 'Los Angeles', 'LA', 8, 34.0522, -118.2437),          -- California
-(11, 'Miami', 'MIA', 9, 25.7617, -80.1918),                -- Florida
-(12, 'Milwaukee', 'MIL', 10, 43.0389, -87.9065),           -- Wisconsin
-(13, 'Minnesota', 'MIN', 11, 46.7296, -94.6859),           -- Minnesota
-(14, 'Brooklyn', 'BKN', 12, 40.6782, -73.9442),            -- New York
-(15, 'New York', 'NY', 12, 40.7128, -74.0060),             -- New York
-(16, 'Orlando', 'ORL', 9, 28.5383, -81.3792),              -- Florida
-(17, 'Indiana', 'IND', 13, 40.2672, -86.1349),             -- Indiana
-(18, 'Philadelphia', 'PHI', 14, 39.9526, -75.1652),        -- Pennsylvania
-(19, 'Phoenix', 'PHX', 15, 33.4484, -112.0740),            -- Arizona
-(20, 'Portland', 'POR', 16, 45.5155, -122.6793),           -- Oregon
-(21, 'Sacramento', 'SAC', 8, 38.5816, -121.4944),          -- California
-(22, 'San Antonio', 'SA', 6, 29.4241, -98.4936),           -- Texas
-(23, 'Oklahoma City', 'OKC', 17, 35.4676, -97.5164),       -- Oklahoma
-(24, 'Toronto', 'TOR', 18, 43.6510, -79.3470),             -- Ontario (Canada)
-(25, 'Utah', 'UTA', 19, 39.3200, -111.0937),               -- Utah
-(26, 'Memphis', 'MEM', 20, 35.1495, -90.0490),             -- Tennessee
-(27, 'Washington', 'WAS', 21, 38.9072, -77.0369),          -- District of Columbia
-(28, 'Detroit', 'DET', 22, 42.3314, -83.0458),             -- Michigan
-(29, 'Charlotte', 'CHA', 23, 35.2271, -80.8431);           -- North Carolina
-
+INSERT INTO cities (name, abbreviation, state_id, coordinate_x, coordinate_y) VALUES
+('Atlanta', 'ATL', 1, 33.7490, -84.3880),               -- Georgia
+( 'Boston', 'BOS', 2, 42.3601, -71.0589),                -- Massachusetts
+('Cleveland', 'CLE', 3, 41.4995, -81.6954),             -- Ohio
+('New Orleans', 'NO', 4, 29.9511, -90.0715),            -- Louisiana
+('Chicago', 'CHI', 5, 41.8781, -87.6298),               -- Illinois
+('Dallas', 'DAL', 6, 32.7767, -96.7970),                -- Texas
+('Denver', 'DEN', 7, 39.7392, -104.9903),               -- Colorado
+('Golden State', 'GSW', 8, 37.7749, -122.4194),         -- California
+('Houston', 'HOU', 6, 29.7604, -95.3698),               -- Texas
+('Los Angeles', 'LA', 8, 34.0522, -118.2437),          -- California
+('Miami', 'MIA', 9, 25.7617, -80.1918),                -- Florida
+('Milwaukee', 'MIL', 10, 43.0389, -87.9065),           -- Wisconsin
+('Minnesota', 'MIN', 11, 46.7296, -94.6859),           -- Minnesota
+('Brooklyn', 'BKN', 12, 40.6782, -73.9442),            -- New York
+('New York', 'NY', 12, 40.7128, -74.0060),             -- New York
+('Orlando', 'ORL', 9, 28.5383, -81.3792),              -- Florida
+('Indiana', 'IND', 13, 40.2672, -86.1349),             -- Indiana
+('Philadelphia', 'PHI', 14, 39.9526, -75.1652),        -- Pennsylvania
+('Phoenix', 'PHX', 15, 33.4484, -112.0740),            -- Arizona
+('Portland', 'POR', 16, 45.5155, -122.6793),           -- Oregon
+('Sacramento', 'SAC', 8, 38.5816, -121.4944),          -- California
+('San Antonio', 'SA', 6, 29.4241, -98.4936),           -- Texas
+('Oklahoma City', 'OKC', 17, 35.4676, -97.5164),       -- Oklahoma
+('Toronto', 'TOR', 18, 43.6510, -79.3470),             -- Ontario (Canada)
+('Utah', 'UTA', 19, 39.3200, -111.0937),               -- Utah
+('Memphis', 'MEM', 20, 35.1495, -90.0490),             -- Tennessee
+('Washington', 'WAS', 21, 38.9072, -77.0369),          -- District of Columbia
+('Detroit', 'DET', 22, 42.3314, -83.0458),             -- Michigan
+('Charlotte', 'CHA', 23, 35.2271, -80.8431);           -- North Carolina

--- a/database/table_creation/table_quotes.sql
+++ b/database/table_creation/table_quotes.sql
@@ -1,8 +1,11 @@
+PRAGMA foreign_keys = ON;
+
 CREATE TABLE IF NOT EXISTS quotes (
     quote_id INTEGER PRIMARY KEY AUTOINCREMENT,
     player_id INTEGER,
     quote TEXT,
     FOREIGN KEY (player_id) REFERENCES players(player_id)
+        ON DELETE CASCADE
 );
 
 INSERT INTO quotes (player_id, quote)

--- a/database/table_creation/table_states.sql
+++ b/database/table_creation/table_states.sql
@@ -1,36 +1,36 @@
--- STATES TABLE
+PRAGMA foreign_keys = ON;
+
 CREATE TABLE IF NOT EXISTS states (
-    state_id INTEGER PRIMARY KEY,
-    name  varchar,
+    state_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name  varchar NOT NULL,
     country_id INTEGER,
 
     FOREIGN KEY (country_id) REFERENCES countries(country_id)
+        ON DELETE CASCADE
 );
 
-INSERT INTO states (state_id, name, country_id)
+INSERT INTO states (name, country_id)
 VALUES
-    (1, 'Georgia', 184),
-    (2, 'Massachusetts', 184),
-    (3, 'Ohio', 184),
-    (4, 'Louisiana', 184),
-    (5, 'Illinois', 184),
-    (6, 'Texas', 184),
-    (7, 'Colorado', 184),
-    (8, 'California', 184),
-    (9, 'Florida', 184),
-    (10, 'Wisconsin', 184),
-    (11, 'Minnesota', 184),
-    (12, 'New York', 184),
-    (13, 'Indiana', 184),
-    (14, 'Pennsylvania', 184),
-    (15, 'Arizona', 184),
-    (16, 'Oregon', 184),
-    (17, 'Oklahoma', 184),
-    (18, 'Ontario', 32),  -- Ontario has a different country_id
-    (19, 'Utah', 184),
-    (20, 'Tennessee', 184),
-    (21, 'District of Columbia', 184),
-    (22, 'Michigan', 184),
-    (23, 'North Carolina', 184);
-
-SELECT * FROM states limit 5;
+    ('Georgia', 184),
+    ('Massachusetts', 184),
+    ('Ohio', 184),
+    ('Louisiana', 184),
+    ('Illinois', 184),
+    ('Texas', 184),
+    ('Colorado', 184),
+    ('California', 184),
+    ('Florida', 184),
+    ('Wisconsin', 184),
+    ('Minnesota', 184),
+    ('New York', 184),
+    ('Indiana', 184),
+    ('Pennsylvania', 184),
+    ('Arizona', 184),
+    ('Oregon', 184),
+    ('Oklahoma', 184),
+    ('Ontario', 32),  -- Ontario has a different country_id
+    ('Utah', 184),
+    ('Tennessee', 184),
+    ('District of Columbia', 184),
+    ('Michigan', 184),
+    ('North Carolina', 184);


### PR DESCRIPTION
ON DELETE CASCADE command added to 3 table, also I converted city_id and state_id autoincrement, it may be useful when adding new data.

I follow this tutorial:
https://www.sqlitetutorial.net/sqlite-foreign-key/
probably we need to add '''PRAGMA foreign_keys = ON;''' to all table creation


I encountered some issues, I think it will be resolved after updating all tables. So for now, I did not update database.
